### PR TITLE
Quote use of get_shim_versions & preset_versions

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -616,7 +616,7 @@ with_shim_executable() {
   }
 
   select_from_preset_version() {
-    grep -f <(get_shim_versions) <(preset_versions) | head -n 1 | xargs echo
+    grep -f <'(get_shim_versions)' <'(preset_versions)' | head -n 1 | xargs echo
   }
 
   select_version() {


### PR DESCRIPTION
# Summary

I've been getting a syntax error ever since I upgraded to the newest master and tracked it down to functions that needed escaping (I don't remember where I got the escaping idea - maybe [issue 581](https://github.com/asdf-vm/asdf/issues/581).

Fixes this syntax error:
```
asdf
/Users/john/.asdf/lib/utils.sh: line 619: syntax error near unexpected token `('
/Users/john/.asdf/lib/utils.sh: line 619: `    grep -f <(get_shim_versions) <(preset_versions) | head -n 1 | xargs echo'
version: v0.7.5-8826dc7
...
```

## Other Information
* Doing a git bisect, I found that the error first appeared in [(two places) in `shim-exec.sh`](https://github.com/JohnB/asdf/commit/e51f778b6108d3d48d04995050e343b6ccd5fb9c#diff-2c3abb256e2eeaf95d19f2ab0bbfadf1R15-R23) and one of them later moved to `utils.sh` where I ran into it.

* I'm running on macOS 10.15.1 (19B88).

